### PR TITLE
Small change to allow easy support of multiple providers

### DIFF
--- a/lib/ngx-oauth/config.lua
+++ b/lib/ngx-oauth/config.lua
@@ -10,6 +10,7 @@ local map             = util.map
 local par             = util.partial
 local starts_with     = util.starts_with
 
+local oauth_config_prefix = ngx.var['oauth_config_prefix'] or 'oauth_'
 local DEFAULTS = {
   client_id         = '',
   client_secret     = '',
@@ -30,7 +31,7 @@ local OAAS_ENDPOINT_VARS = {'authorization_url', 'token_url', 'userinfo_url'}
 
 
 local load_from_ngx = par(map, function(default_value, key)
-    return util.default(ngx.var['oauth_'..key], default_value)
+    return util.default(ngx.var[oauth_config_prefix..key], default_value)
   end, DEFAULTS)
 
 local function validate (conf)

--- a/lib/ngx-oauth/config.lua
+++ b/lib/ngx-oauth/config.lua
@@ -10,7 +10,7 @@ local map             = util.map
 local par             = util.partial
 local starts_with     = util.starts_with
 
-local oauth_config_prefix = ngx.var['oauth_config_prefix'] or 'oauth_'
+local oauth_config_prefix = nil
 local DEFAULTS = {
   client_id         = '',
   client_secret     = '',
@@ -72,6 +72,7 @@ local M = {}
 -- @treturn nil|string Validation error, or `false` if no validation
 --   error was found.
 function M.load ()
+  oauth_config_prefix = ngx.var['oauth_config_prefix'] or 'oauth_'
   local conf = load_from_ngx()
 
   if not is_absolute_url(conf.redirect_uri) then

--- a/ngx-oauth-dev-0.rockspec
+++ b/ngx-oauth-dev-0.rockspec
@@ -4,7 +4,7 @@ package = 'ngx-oauth'
 version = 'dev-0'
 
 source = {
-  url = 'git://github.com/jirutka/ngx-oauth.git',
+  url = 'git://github.com/subzerocloud/ngx-oauth.git',
   branch = 'master'
 }
 

--- a/ngx-oauth-dev-0.rockspec
+++ b/ngx-oauth-dev-0.rockspec
@@ -4,7 +4,7 @@ package = 'ngx-oauth'
 version = 'dev-0'
 
 source = {
-  url = 'git://github.com/subzerocloud/ngx-oauth.git',
+  url = 'git://github.com/jirutka/ngx-oauth.git',
   branch = 'master'
 }
 


### PR DESCRIPTION
This is a small change that allows configuring multiple oauth providers and serving them from the same location.

here is a sample
```
# initialize common oauth configuration
set $oauth_config_prefix '';
set $oauth_redirect_uri '_/oauth/callback';
set $oauth_success_uri '/';

# # google oauth configuration
set $google_redirect_uri "${oauth_redirect_uri}?provider=google";
set $google_success_uri "${oauth_success_uri}";
set $google_client_id '...';
set $google_client_secret '...';
set $google_authorization_url '...';
set $google_token_url '...';
set $google_userinfo_url '...';
set $google_scope '...';

# github oauth configuration
set $github_redirect_uri "${oauth_redirect_uri}?provider=github";
set $github_success_uri "${oauth_success_uri}";
set $github_client_id '...';
set $github_client_secret '...';
set $github_authorization_url '...';
set $github_token_url '...';
set $github_userinfo_url '...';
set $github_scope '...';


location /_oauth/login {
    set $oauth_config_prefix "${arg_provider}_";
    content_by_lua_file '../luajit/share/lua/5.1/ngx-oauth-login.lua';
}
```

PS: if you decide to merge this, please "squash" the commits for a cleaner history.
Thank you